### PR TITLE
Fixing two small template bugs

### DIFF
--- a/views/index.tpl
+++ b/views/index.tpl
@@ -35,7 +35,7 @@
 
             $('#result tbody').on('click', 'tr', function() {
                 var d = table.row( this ).data();
-                $("#modal-fingerprint").text(d[1]);
+                $("#modal-fingerprint").text($(this).data("fingerprint"));
                 hljs.highlightBlock($('#modal-fingerprint').get(0));
                 $('#modal-query').text($(this).data("example"));
                 hljs.highlightBlock($('#modal-query').get(0));
@@ -106,6 +106,7 @@ body { font-size: 140%; }
         <tbody>
         % for row in parsed_result.get("classes"):
             <tr
+                    data-fingerprint="{{row.get('fingerprint')}}"
                     data-example="{{row.get('example').get('query')}}"
                     data-first_seen="{{row.get('ts_min')}}"
                     data-last_seen="{{row.get('ts_max')}}"

--- a/views/index.tpl
+++ b/views/index.tpl
@@ -112,7 +112,7 @@ body { font-size: 140%; }
                     data-last_seen="{{row.get('ts_max')}}"
                     data-rows_examined="{{row.get('Rows_examined')}}"
                     >
-                <td>{{row.get("metrics").get("db").get("value")}}</td>
+                <td>{{row.get("metrics").get("db", {}).get("value", "N/A")}}</td>
                 <td>{{row.get("fingerprint")}}</td>
                 <td>{{row.get("query_count")}}</td>
                 <td>{{row.get("metrics").get("Query_time").get("median")}}</td>


### PR DESCRIPTION
Hi, I know this is a old repo but since I came across this and found the tool useful with some minor modifications, I figured I would submit those.

This PR fixes two issues:

1. At least with pt-query-digest 3.1.0, I've found a case where the `db` key is not part of the metrics in some cases. This results in an `AttributeError` when trying to start the server, as it can't call `get()` on it. I fixed this by setting a default of an empty dictionary, so `.get()` can be called, and then on the value return `N/A` instead of the actual DB name.

2. When clicking one of the rows to open the modal, I've found that the fingerprint query was escaped twice - this is because we're pulling it out of the DOM text where it had already been escaped once. To fix this, I made it like the example so it's also stored as an attribute, and we're pulling it out of the attribute which hasn't been escaped.